### PR TITLE
Add tests for timeline index and clarify build steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,12 @@
 - Use `tools/archive_link.py` to create new archives when needed.
 
 ## Development workflow
+0. Before starting, sync with the latest main branch:
+   - `git pull --ff-only origin main`
 1. Modify source files (`timeline/*.yaml`, `posts/*.md`, etc.).
-2. Rebuild derived files (timeline index, footnotes) if relevant.
+2. Rebuild derived files (timeline index, footnotes) if relevant:
+   - `python scripts/build_timeline_index.py` (commits `timeline/index.json`; tests fail if stale)
+   - `python scripts/build_footnotes.py`
 3. Run tests:
    - `pytest -q`
    - `python scripts/link_check.py --csv link_check.csv`

--- a/tests/test_timeline_index.py
+++ b/tests/test_timeline_index.py
@@ -38,5 +38,23 @@ class TimelineIndexTests(unittest.TestCase):
         self.assertEqual(hashes["b.yml"], hashlib.sha256("evt2".encode("utf-8")).hexdigest())
 
 
+class RepoIndexUpToDateTests(unittest.TestCase):
+    def test_repo_index_matches_sources(self):
+        mod = load_module("build_timeline_index", os.path.join(SCRIPTS, "build_timeline_index.py"))
+        with tempfile.TemporaryDirectory(prefix="repo_index_") as tmp:
+            out_json = os.path.join(tmp, "index.json")
+            mod.main(os.path.join(REPO_ROOT, "timeline"), out_json)
+            with open(out_json, "r", encoding="utf-8") as f:
+                generated = json.load(f)
+            repo_index = os.path.join(REPO_ROOT, "timeline", "index.json")
+            with open(repo_index, "r", encoding="utf-8") as f:
+                existing = json.load(f)
+        self.assertEqual(
+            generated,
+            existing,
+            msg="timeline/index.json is out of date. Run scripts/build_timeline_index.py",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/timeline/index.json
+++ b/timeline/index.json
@@ -1,5 +1,7 @@
-Wrote timeline/index.json with 126 events
-01-30",
+{
+  "events": [
+    {
+      "date": "2017-01-30",
       "title": "Executive Order 13771: Reducing Regulation and Controlling Regulatory Costs",
       "summary": "Order established a 'two-for-one' rule for federal regulations, later rescinded in 2021.",
       "tags": [
@@ -7,7 +9,10 @@ Wrote timeline/index.json with 126 events
         "regulation"
       ],
       "citations": [
-        "https://www.federalregister.gov/documents/2017/02/03/2017-02451/reducing-regulation-and-controlling-regulatory-costs"
+        {
+          "url": "https://www.federalregister.gov/d/2017-02451",
+          "archived": "https://web.archive.org/web/20170203/https://www.federalregister.gov/documents/2017/02/03/2017-02451/reducing-regulation-and-controlling-regulatory-costs"
+        }
       ],
       "id": "executive-order-13771-reducing-regulation-and-controlling-regulatory-costs",
       "location": null,
@@ -478,7 +483,10 @@ Wrote timeline/index.json with 126 events
       ],
       "citations": [
         "https://www.supremecourt.gov/opinions/23pdf/22-859_1924.pdf",
-        "https://www.reuters.com/legal/legalindustry/jurys-not-out-supreme-courts-jarkesy-decision-limits-secs-use-administrative-2024-07-18/"
+        {
+          "url": "https://www.reuters.com/legal/legalindustry/jurys-not-out-supreme-courts-jarkesy-decision-limits-secs-use-administrative-2024-07-18/",
+          "archived": "https://web.archive.org/web/20250724005258/https://www.reuters.com/legal/legalindustry/jurys-not-out-supreme-courts-jarkesy-decision-limits-secs-use-administrative-2024-07-18/"
+        }
       ],
       "notes": "",
       "_file": "2024-06-27_scotus_sec_v_jarkesy.yaml",
@@ -1421,7 +1429,7 @@ Wrote timeline/index.json with 126 events
         "enforcement"
       ],
       "citations": [
-        "https://www.transportation.gov/briefing-room/enforcement-policy-grace-period-aug-1-2025"
+        "https://www.transportation.gov/briefing-room/enforcement-policy-grace-period-through-august-1-2025"
       ],
       "_file": "2025-04-02-dot-enforcement-grace.yaml",
       "_id_hash": "008ddd0da030a38bec8ebc491dafaaa9f56dd25edb4891a4778bd747ffea80ab"
@@ -1809,7 +1817,7 @@ Wrote timeline/index.json with 126 events
       "citations": [
         "https://www.whitehouse.gov/presidential-actions/2025/06/department-of-defense-security-for-the-protection-of-department-of-homeland-security-functions/",
         "https://www.govinfo.gov/app/details/DCPD-202500672",
-        "https://news.usni.org/2025/06/09/marines-deploy-to-los-angeles",
+        "https://news.usni.org/2025/06/09/700-marines-deploying-to-downtown-los-angeles",
         "https://www.brookings.edu/articles/how-can-the-president-put-soldiers-on-the-streets-of-los-angeles/",
         "https://www.aila.org/presidential-memo-on-dod-security-for-the-protection-of-dhs-functions"
       ],
@@ -1928,7 +1936,6 @@ Wrote timeline/index.json with 126 events
         "state-courts"
       ],
       "citations": [
-        "https://apnews.com/article/88de13189060dfd42069ed558ccbcad9",
         "https://www.ajc.com/politics/2025/06/georgia-high-court-rejects-election-boards-rules-for-hand-counts-and-inquiries/"
       ],
       "notes": "",
@@ -1945,7 +1952,7 @@ Wrote timeline/index.json with 126 events
         "protests"
       ],
       "citations": [
-        "https://apnews.com/article/4b9b062785bde9428a3155812fd092de"
+        "https://cpj.org/2025/06/law-enforcement-injure-multiple-journalists-others-assaulted-while-covering-los-angeles-protests/"
       ],
       "id": "ap-reporters-shot-with-rubber-bullets-roughed-up-covering-la-protests",
       "location": null,

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Debugging Democracy — Interactive Timeline</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/tailwind.min.css" rel="stylesheet">
   <style>
     html, body { height: 100%; }
     body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
@@ -24,6 +24,9 @@ const e = React.createElement;
 function App() {
   const [events, setEvents] = React.useState([]);
   React.useEffect(() => {
+    if (location.protocol === "file:") {
+      console.error("Use a local HTTP server (e.g. 'python -m http.server') to view the timeline.");
+    }
     fetch("../timeline/index.json")
       .then((r) => r.json())
       .then((d) => setEvents(d.events || []))


### PR DESCRIPTION
## Summary
- document pulling latest main and regenerating timeline index
- add regression test ensuring timeline/index.json matches sources
- improve viewer: use Tailwind CSS bundle and warn when opened from file://
- regenerate timeline/index.json

## Testing
- `pytest -q`
- `python scripts/link_check.py --csv link_check.csv`

------
https://chatgpt.com/codex/tasks/task_e_689a4a29d83483259bcafd98868f7468